### PR TITLE
Deal with WatchKit files; miscellaneous fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,6 @@ Then, just do the following:
   $ git clone https://github.com/saucelabs/isign.git
   $ cd isign
   $ dev/setup.sh 
-  $ ./INSTALL.sh develop 
   $ ./run_tests.sh
 
 If the tests don't pass please `file an issue <https://github.com/saucelabs/isign/issues>`__. Please keep the tests up to date as you develop.

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -9,4 +9,4 @@ SRC_DIR=$PWD
 popd >/dev/null
 
 pip install -U -r ${DEV_DIR}/requirements.txt
-pip install -U -e ${SRC_DIR}
+../INSTALL.sh develop

--- a/isign/bundle.py
+++ b/isign/bundle.py
@@ -27,7 +27,9 @@ def is_info_plist_native(plist):
     """ If an bundle is for native iOS, it has these properties in the Info.plist """
     return (
         'CFBundleSupportedPlatforms' in plist and
-        'iPhoneOS' in plist['CFBundleSupportedPlatforms']
+        ('iPhoneOS' in plist['CFBundleSupportedPlatforms']
+            or
+         'WatchOS' in plist['CFBundleSupportedPlatforms'])
     )
 
 

--- a/isign/bundle.py
+++ b/isign/bundle.py
@@ -134,26 +134,13 @@ class App(Bundle):
 
     def __init__(self, path):
         super(App, self).__init__(path)
-        self.entitlements_path = join(self.path,
-                                      'Entitlements.plist')
         self.provision_path = join(self.path,
                                    'embedded.mobileprovision')
 
     def provision(self, provision_path):
         shutil.copyfile(provision_path, self.provision_path)
 
-    def create_entitlements(self, team_id):
-        entitlements = {
-            "keychain-access-groups": [team_id + '.*'],
-            "com.apple.developer.team-identifier": team_id,
-            "application-identifier": team_id + '.*',
-            "get-task-allow": True
-        }
-        biplist.writePlist(entitlements, self.entitlements_path, binary=False)
-        # log.debug("wrote Entitlements to {0}".format(self.entitlements_path))
-
     def resign(self, signer, provisioning_profile):
         """ signs app in place """
         self.provision(provisioning_profile)
-        self.create_entitlements(signer.team_id)
         super(App, self).resign(signer)

--- a/isign/codesig.py
+++ b/isign/codesig.py
@@ -84,6 +84,14 @@ class Codesig(object):
         blob = self.get_blob(magic)
         return macho_cs.Blob_.build(blob)
 
+    def get_entitlements(self):
+        try:
+            entitlements = self.get_blob('CSMAGIC_ENTITLEMENT')
+        except KeyError:
+            log.debug("no entitlements found")
+            # TODO: something more clever with this error
+        return self.get_blob_data(entitlements)
+
     def set_entitlements(self, entitlements_path):
         # log.debug("entitlements:")
         try:

--- a/isign/signable.py
+++ b/isign/signable.py
@@ -23,7 +23,12 @@ log = logging.getLogger(__name__)
 class Signable(object):
     __metaclass__ = ABCMeta
 
+    # must be overridden by concrete classes
     slot_classes = []
+
+    # only Executables need to have entitlements.
+    # other signable types won't need them
+    needs_entitlements = False
 
     def __init__(self, path):
         log.debug("working on {0}".format(path))
@@ -36,6 +41,7 @@ class Signable(object):
 
         self.m = macho.MachoFile.parse_stream(self.f)
         self.arches = self._parse_arches()
+
 
     def _parse_arches(self):
         """ parse architectures and associated Codesig """
@@ -136,6 +142,7 @@ class Signable(object):
 
 class Executable(Signable):
     """ The main executable of an app. """
+    needs_entitlements = True
     slot_classes = [EntitlementsSlot,
                     ResourceDirSlot,
                     RequirementsSlot,


### PR DESCRIPTION
Review: @classam or @mhan, please.

Several fixes got folded into this PR:

Simplified the developer install. (`README.rst`, `dev/setup.sh`)

Stopgap fix for Issue #20, by removing WatchKit files before re-signing (`isign/archive.py`)

In my attempt to fix #20, I also modified how entitlements are created (`isign/codesig.py`, `isign/bundle.py`). Previously we made an external Entitlements file; now we write the Entitlements data directly into the binaries. Also, a `needs_entitlements` property is attached to some kinds of `Signable`.