### PR TITLE
Fix publishing to pypi

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,2 +1,3 @@
 nose
 pytest
+twine

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -10,11 +10,6 @@ for app in unzip zip; do
     fi
 done
 
-# ensure version.json exists in dev
-if [[ -z $BUILD_TAG ]]; then
-    ./version.sh json | python -mjson.tool >/dev/null
-fi
-
 # run test suite
 find . -name '*.pyc' -delete
 pushd tests >/dev/null


### PR DESCRIPTION
Fixes #27 

@mhan please review after merge when you get the chance. Going to merge anyway because the only real way to test it is to merge to master, and we're currently broken for people using this library. (Done other tests with personal account)

Because directories are moved around by the test procedure, rebuilding
and re-uploading seems not to work (at least when jenkins does it).

Also upload with twine, which is more secure and allows us to upload
a prebuilt package rather than always rebuilding

Also fixed erroneous double check for version.json; does not work in dev.