### PR TITLE
Fix appex signing bug caused by case sensitivity

### DIFF
--- a/isign/bundle.py
+++ b/isign/bundle.py
@@ -85,7 +85,7 @@ class Bundle(object):
                 dylib = signable.Dylib(dylib_path)
                 dylib.sign(self, signer)
 
-        plugins_path = join(self.path, 'Plugins')
+        plugins_path = join(self.path, 'PlugIns')
         if exists(plugins_path):
             # sign the appex executables
             appex_paths = glob.glob(join(plugins_path, '*.appex'))


### PR DESCRIPTION
- OS X is case insensitive but Linux isnt

sorry about missing this...

the symptom/side effect would be that appex would be skipped on Linux and not OS X boxes.