### PR TITLE
fix #50, signable in wrong mode

### DIFF
--- a/isign/signable.py
+++ b/isign/signable.py
@@ -152,9 +152,11 @@ class Signable(object):
         macho.MachoFile.build_stream(self.m, temp)
         temp.close()
 
+        # make copy have same permissions
+        mode = os.stat(self.path).st_mode
+        os.chmod(temp.name, mode)
         # log.debug("moving temporary file to {0}".format(self.path))
         os.rename(temp.name, self.path)
-
 
 class Executable(Signable):
     """ The main executable of an app. """

--- a/isign/signable.py
+++ b/isign/signable.py
@@ -158,6 +158,7 @@ class Signable(object):
         # log.debug("moving temporary file to {0}".format(self.path))
         os.rename(temp.name, self.path)
 
+
 class Executable(Signable):
     """ The main executable of an app. """
     slot_classes = [EntitlementsSlot,


### PR DESCRIPTION
Simple fix, ensure that re-signed signables have the same mode as the original.

Please review: @cfal 