### PR TITLE
fix non-ascii characters

### DIFF
--- a/isign/archive.py
+++ b/isign/archive.py
@@ -125,7 +125,7 @@ class AppZip(object):
 
     def unarchive_to_temp(self):
         containing_dir = make_temp_dir()
-        call([get_helper('unzip'), "-qu", self.path, "-d", containing_dir])
+        call([get_helper('unzip'), "-O", "UTF-8", "-qu", self.path, "-d", containing_dir])
         app_dir = abspath(os.path.join(containing_dir, self.relative_app_dir))
         return containing_dir, App(app_dir)
 

--- a/isign/code_resources.py
+++ b/isign/code_resources.py
@@ -147,9 +147,9 @@ class ResourceBuilder(object):
                     val['optional'] = True
 
                 if len(val) == 1 and 'hash' in val:
-                    file_entries[relative_path] = val['hash']
+                    file_entries[relative_path.decode("utf-8")] = val['hash']
                 else:
-                    file_entries[relative_path] = val
+                    file_entries[relative_path.decode("utf-8")] = val
 
             for dirname in dirs:
                 rule, path, relative_path = self.get_rule_and_paths(root,


### PR DESCRIPTION
non-ascii filename in package will throw UnicodeDecodeError

```
WARNING:root:Traceback (most recent call last):
  File "/opt/AppSignSrv/app/core/__init__.py", line 285, in resign_app
    isign.resign(original_path, **kwargs)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/site-packages/isign/isign.py", line 49, in resign
    info_props)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/site-packages/isign/archive.py", line 280, in resign
    bundle.resign(signer, provisioning_profile)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/site-packages/isign/bundle.py", line 216, in resign
    super(App, self).resign(signer)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/site-packages/isign/bundle.py", line 166, in resign
    self.sign(signer)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/site-packages/isign/bundle.py", line 159, in sign
    self.path)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/site-packages/isign/code_resources.py", line 226, in make_seal
    return write_plist(target_dir, plist)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/site-packages/isign/code_resources.py", line 204, in write_plist
    plistlib.writePlist(plist, fh)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/plistlib.py", line 94, in writePlist
    writer.writeValue(rootObject)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/site-packages/isign/code_resources.py", line 32, in writeValue
    self.oldWriteValue(value)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/plistlib.py", line 252, in writeValue
    self.writeDict(value)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/plistlib.py", line 281, in writeDict
    self.writeValue(value)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/site-packages/isign/code_resources.py", line 32, in writeValue
    self.oldWriteValue(value)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/plistlib.py", line 252, in writeValue
    self.writeDict(value)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/plistlib.py", line 280, in writeDict
    self.simpleElement("key", key)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/plistlib.py", line 172, in simpleElement
    value = _escapeAndEncode(value)
  File "/root/alamis/miniconda2/envs/appsign.sub.core/lib/python2.7/plistlib.py", line 222, in _escapeAndEncode
    return text.encode("utf-8")             # encode as UTF-8
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 0: ordinal not in range(128)
```