### PR TITLE
Change the working directory of zip instead of changing the main prog…

### DIFF
--- a/isign/archive.py
+++ b/isign/archive.py
@@ -142,21 +142,16 @@ class AppZip(object):
         # to construct the zip file. This is the best way to ensure the an unused
         # filename. Also, `zip` won't overwrite existing files, so this is safer.
         temp_zip_dir = None
-        old_cwd = None
         try:
             # need to chdir and use relative paths, because zip is stupid
-            old_cwd = os.getcwd()
-            os.chdir(containing_dir)
             temp_zip_dir = tempfile.mkdtemp(prefix="isign-zip-")
             temp_zip_file = join(temp_zip_dir, 'temp.zip')
-            call([get_helper('zip'), "-qr", temp_zip_file, "."])
+            call([get_helper('zip'), "-qr", temp_zip_file, "."], cwd=containing_dir)
             shutil.move(temp_zip_file, output_path)
             log.info("archived %s to %s" % (cls.__name__, output_path))
         finally:
             if temp_zip_dir is not None and isdir(temp_zip_dir):
                 shutil.rmtree(temp_zip_dir)
-            if old_cwd is not None and isdir(old_cwd):
-                os.chdir(old_cwd)
 
 
 class Ipa(AppZip):


### PR DESCRIPTION
I use isign in a multithreaded program, I've found that zip consumes a lot of time, During this time, other code that uses the current working directory will be wrong.
I can't pass the test of run_tests.sh on my computer, I hope someone can help me to test it..