### PR TITLE
fix bug if cd.data.teamIDOffset is None

### DIFF
--- a/isign/codesig.py
+++ b/isign/codesig.py
@@ -204,7 +204,10 @@ class Codesig(object):
             offset_change = len(changed_bundle_id) - len(cd.data.ident)
             cd.data.ident = changed_bundle_id
             cd.data.hashOffset += offset_change
-            cd.data.teamIDOffset += offset_change
+            if cd.data.teamIDOffset == None:
+                cd.data.teamIDOffset = offset_change
+            else:
+                cd.data.teamIDOffset += offset_change
             cd.length += offset_change
             
         cd.bytes = macho_cs.CodeDirectory.build(cd.data)


### PR DESCRIPTION
there are some ipa which `cd.data.teamIDOffset` is None will get errors as following:

`File "/home/harc/virtualenv_harc/local/lib/python2.7/site-packages/isign/codesig.py", line 207, in set_codedirectory
    cd.data.teamIDOffset += offset_change
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'int'`