### PR TITLE
sha256 signing support

### DIFF
--- a/isign/signer.py
+++ b/isign/signer.py
@@ -98,7 +98,7 @@ class Signer(object):
             msg = "Signing may not work: OpenSSL version is {0}, need {1} !"
             log.warn(msg.format(openssl_version, MINIMUM_OPENSSL_VERSION))
 
-    def sign(self, data):
+    def sign(self, data, digest_algorithm = "sha1"):
         """ sign data, return filehandle """
         cmd = [
             "cms",
@@ -107,7 +107,8 @@ class Signer(object):
             "-signer", self.signer_cert_file,
             "-inkey", self.signer_key_file,
             "-keyform", "pem",
-            "-outform", "DER"
+            "-outform", "DER",
+            "-md", digest_algorithm
         ]
         signature = openssl_command(cmd, data)
         # in some cases we've seen this return a zero length file.


### PR DESCRIPTION
@neilk - I took a stab at adding sha256 support to the signature. Interestingly, I didn't need to modify the `set_signature` method at all. Just had to update the special slots on the sha256 CodeDirectory blob and re-hash them. This allowed me to install on iOS 10. 

Maybe it's my lack of understanding of MachO, but I find this to be really odd. It seems to me that you should need to do something different when creating the CodeDirectory signature, or maybe look for another blob wrapper for the sha256 signature. Perhaps Apple is just not enforcing this at the moment? Or maybe it's my test setup?

Anyway, have a look and let me know what you think.