### PR TITLE
RDC-882 multisign

### DIFF
--- a/bin/multisign
+++ b/bin/multisign
@@ -13,6 +13,7 @@ from isign import isign
 from isign.archive import archive_factory
 from isign.signer import Signer
 import logging
+from multiprocessing import Pool
 
 FORMATTER = logging.Formatter('%(message)s')
 log = logging.getLogger(__name__)
@@ -83,6 +84,24 @@ def get_resigned_path(original_path, credential_dir, prefix):
     return join(original_dir, resigned_name)
 
 
+def resign(ua, credential_dir, resigned_path):
+    """ Given a path to an uncompressed archive, credential directory, and desired
+        output path, resign accordingly """
+
+    # get the credential files, create the 'signer'
+    credential_paths = isign.get_credential_paths(credential_dir)
+    signer = Signer(signer_cert_file=credential_paths['certificate'],
+                    signer_key_file=credential_paths['key'],
+                    apple_cert_file=isign.DEFAULT_APPLE_CERT_PATH)
+
+    # sign it (in place)
+    ua.bundle.resign(signer, credential_paths['provisioning_profile'])
+
+    log.debug("outputing %s", resigned_path)
+    # and archive it there
+    ua.archive(resigned_path)
+
+
 def multisign(original_path, credential_dirs, info_props=None, prefix="_signed_"):
     """ Given a path to an IPA, and paths to credential directories,
         produce re-signed versions of the IPA with each credentials in the
@@ -101,7 +120,7 @@ def multisign(original_path, credential_dirs, info_props=None, prefix="_signed_"
     """
     pass
 
-    # ua is potentially an isign.UncompressedArchive
+    # ua is potentially an isign.archive.UncompressedArchive
     ua = None
 
     archive = archive_factory(original_path)
@@ -115,25 +134,18 @@ def multisign(original_path, credential_dirs, info_props=None, prefix="_signed_"
             # Override info.plist props of the parent bundle
             ua.bundle.update_info_props(info_props)
 
-        for credential_dir in credential_dirs:
-            log.debug("doing %s", credential_dir)
+        # create uncompressed archives for each credential to be signed
+        ua_credential_dir_pairs = [(ua, credential_dirs[0])]
+        for i in range(1, len(credential_dirs)):
+            cloned_ua = ua.clone(ua.path + '_' + str(i))
+            ua_credential_dir_pairs.append((cloned_ua, credential_dirs[i]))
 
-            # get the credential files, create the 'signer'
-            credential_paths = isign.get_credential_paths(credential_dir)
-            signer = Signer(signer_cert_file=credential_paths['certificate'],
-                            signer_key_file=credential_paths['key'],
-                            apple_cert_file=isign.DEFAULT_APPLE_CERT_PATH)
-
-            # TODO copy it N times, create UAs to start from
-
-            # sign it (in place)
-            ua.bundle.resign(signer, credential_paths['provisioning_profile'])
-
+        # sign each with credentials
+        for pair in ua_credential_dir_pairs:
+            (ua, credential_dir) = pair
+            log.debug("doing %s %s", ua.path, credential_dir)
             resigned_path = get_resigned_path(original_path, credential_dir, prefix)
-
-            log.debug("outputing %s", resigned_path)
-            # and archive it there
-            ua.archive(resigned_path)
+            resign(ua, credential_dir, resigned_path)
 
     except isign.NotSignable as e:
         msg = "Not signable: <{0}>: {1}\n".format(input_path, e)
@@ -167,5 +179,11 @@ if __name__ == '__main__':
 
     log.debug('got credential paths: {}'.format(', '.join(args.credential_dirs)))
     log.debug('got incoming app: {}'.format(args.app))
+
+    # ensure basenames are unique
+    unique_basenames = set([basename(p) for p in args.credential_dirs])
+    if len(args.credential_dirs) != len(unique_basenames):
+        raise Exception('Credential directories do not have unique basenames. '
+                        'Cannot name output archives automatically. Sorry!')
 
     multisign(args.app, args.credential_dirs, info_props)

--- a/bin/multisign
+++ b/bin/multisign
@@ -34,9 +34,6 @@ def absolute_path_argument(path):
 
 
 def parse_args():
-    # note that for arguments which eventually get fed into
-    # isign.resign, we deliberately don't set defaults. The kwarg
-    # defaults in isign.resign will be used
     parser = argparse.ArgumentParser(
         description='From a single IPA, generate multiple re-signed IPAs simultaneously')
     parser.add_argument(

--- a/bin/multisign
+++ b/bin/multisign
@@ -8,7 +8,7 @@
 # Depends on the existence of external `zip` and `unzip` programs.
 
 import argparse
-from os.path import abspath, basename, dirname, expanduser, join, splitext
+from os.path import abspath, basename, dirname, expanduser, isdir, join
 from isign import isign
 from isign.archive import archive_factory
 from isign.signer import Signer
@@ -88,6 +88,7 @@ def resign(ua, credential_dir, resigned_path):
     """ Given a path to an uncompressed archive, credential directory, and desired
         output path, resign accordingly """
 
+    log.debug('resigning with %s %s -> %s', ua.path, credential_dir, resigned_path)
     # get the credential files, create the 'signer'
     credential_paths = isign.get_credential_paths(credential_dir)
     signer = Signer(signer_cert_file=credential_paths['certificate'],
@@ -125,7 +126,7 @@ def multisign(original_path, credential_dirs, info_props=None, prefix="_signed_"
 
     archive = archive_factory(original_path)
     if archive is None:
-        log.debug("that didn't look like an app...")
+        log.debug("%s didn't look like an app...", original_path)
         return
 
     try:
@@ -140,12 +141,15 @@ def multisign(original_path, credential_dirs, info_props=None, prefix="_signed_"
             cloned_ua = ua.clone(ua.path + '_' + str(i))
             ua_credential_dir_pairs.append((cloned_ua, credential_dirs[i]))
 
-        # sign each with credentials
+        # sign each uncompressed archive with credentials, and make archives
         for pair in ua_credential_dir_pairs:
-            (ua, credential_dir) = pair
-            log.debug("doing %s %s", ua.path, credential_dir)
-            resigned_path = get_resigned_path(original_path, credential_dir, prefix)
-            resign(ua, credential_dir, resigned_path)
+            try:
+                (ua, credential_dir) = pair
+                log.debug("doing %s %s", ua.path, credential_dir)
+                resigned_path = get_resigned_path(original_path, credential_dir, prefix)
+                resign(ua, credential_dir, resigned_path)
+            finally:
+                ua.remove()
 
     except isign.NotSignable as e:
         msg = "Not signable: <{0}>: {1}\n".format(input_path, e)
@@ -153,7 +157,7 @@ def multisign(original_path, credential_dirs, info_props=None, prefix="_signed_"
         raise
 
     finally:
-        if ua is not None:
+        if ua is not None and isdir(ua.path):
             ua.remove()
 
 

--- a/bin/multisign
+++ b/bin/multisign
@@ -8,7 +8,10 @@
 # Depends on the existence of external `zip` and `unzip` programs.
 
 import argparse
-from os.path import abspath, expanduser
+from os.path import abspath, basename, dirname, expanduser, join, splitext
+from isign import isign
+from isign.archive import archive_factory
+from isign.signer import Signer
 import logging
 
 FORMATTER = logging.Formatter('%(message)s')
@@ -34,19 +37,26 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description='From a single IPA, generate multiple re-signed IPAs simultaneously')
     parser.add_argument(
-        '-i', '--ipa',
-        dest='ipa',
+        '-a', '--app',
+        dest='app',
         required=True,
         metavar='<file>',
         type=absolute_path_argument,
-        help='Path to input IPA'
+        help='Path to input app'
     )
     parser.add_argument(
-        'credential_paths',
+        'credential_dirs',
         nargs='+',
         metavar='<directory>',
         type=absolute_path_argument,
         help='Paths to directories containing credentials with standardized names'
+    )
+    parser.add_argument(
+        '-i', '--info',
+        dest='info_props',
+        required=False,
+        metavar='<Info.plist properties>',
+        help='List of comma-delimited key=value pairs of Info.plist properties to override'
     )
     parser.add_argument(
         '-v', '--verbose',
@@ -59,6 +69,83 @@ def parse_args():
     return parser.parse_args()
 
 
+def get_resigned_path(original_path, credential_dir, prefix):
+    """ Given:
+            original_path=/path/to/original/app.ipa,
+            credential_dir = /home/me/cred1
+            prefix = '_foo_'
+        returns:
+            /path/to/original/_foo_cred1_app.ipa,
+    """
+    original_name = basename(original_path)
+    original_dir = dirname(original_path)
+    resigned_name = prefix + basename(credential_dir) + '_' + original_name
+    return join(original_dir, resigned_name)
+
+
+def multisign(original_path, credential_dirs, info_props=None, prefix="_signed_"):
+    """ Given a path to an IPA, and paths to credential directories,
+        produce re-signed versions of the IPA with each credentials in the
+        same directory as the original. e.g., when
+
+            original_path=/path/to/original/app.ipa,
+            credential_dirs = ['/home/me/cred1', '/home/me/cred2']
+            prefix = '_foo_'
+
+        It will generate resigned ipa archives like:
+            /path/to/original/_foo_cred1_app.ipa,
+            /path/to/original/_foo_cred2_app.ipa
+
+        If info_props are provided, it will overwrite those properties in
+        the app's Info.plist.
+    """
+    pass
+
+    # ua is potentially an isign.UncompressedArchive
+    ua = None
+
+    archive = archive_factory(original_path)
+    if archive is None:
+        log.debug("that didn't look like an app...")
+        return
+
+    try:
+        ua = archive.unarchive_to_temp()
+        if info_props:
+            # Override info.plist props of the parent bundle
+            ua.bundle.update_info_props(info_props)
+
+        for credential_dir in credential_dirs:
+            log.debug("doing %s", credential_dir)
+
+            # get the credential files, create the 'signer'
+            credential_paths = isign.get_credential_paths(credential_dir)
+            signer = Signer(signer_cert_file=credential_paths['certificate'],
+                            signer_key_file=credential_paths['key'],
+                            apple_cert_file=isign.DEFAULT_APPLE_CERT_PATH)
+
+            # TODO copy it N times, create UAs to start from
+
+            # sign it (in place)
+            ua.bundle.resign(signer, credential_paths['provisioning_profile'])
+
+            resigned_path = get_resigned_path(original_path, credential_dir, prefix)
+
+            log.debug("outputing %s", resigned_path)
+            # and archive it there
+            ua.archive(resigned_path)
+
+    except isign.NotSignable as e:
+        msg = "Not signable: <{0}>: {1}\n".format(input_path, e)
+        log.info(msg)
+        raise
+
+    finally:
+        if ua is not None:
+            ua.remove()
+
+
+
 if __name__ == '__main__':
     args = parse_args()
 
@@ -68,5 +155,17 @@ if __name__ == '__main__':
         level = logging.INFO
     log_to_stderr(level)
 
-    log.debug('got credential paths: {}'.format(', '.join(args.credential_paths)))
-    log.debug('got incoming IPA: {}'.format(args.ipa))
+    # Convert the Info.plist property pairs to a dict format
+    info_props = None
+    if args.info_props:
+        info_props = {}
+        for arg in args.info_props.split(','):
+            i = arg.find('=')
+            if i < 0:
+                raise Exception('Invalid Info.plist argument: ' + arg)
+            info_props[arg[0:i]] = arg[i + 1:]
+
+    log.debug('got credential paths: {}'.format(', '.join(args.credential_dirs)))
+    log.debug('got incoming app: {}'.format(args.app))
+
+    multisign(args.app, args.credential_dirs, info_props)

--- a/bin/multisign
+++ b/bin/multisign
@@ -180,7 +180,7 @@ def multisign(original_path, credential_dirs, info_props=None, prefix="_signed_"
         p.map(resign, resign_args)
 
     except isign.NotSignable as e:
-        msg = "Not signable: <{0}>: {1}\n".format(input_path, e)
+        msg = "Not signable: <{0}>: {1}\n".format(original_path, e)
         log.info(msg)
         raise
 

--- a/bin/multisign
+++ b/bin/multisign
@@ -16,6 +16,7 @@ import logging
 from multiprocessing import Pool
 
 FORMATTER = logging.Formatter('%(message)s')
+MAX_PROCESSES = 1
 log = logging.getLogger(__name__)
 
 
@@ -84,23 +85,35 @@ def get_resigned_path(original_path, credential_dir, prefix):
     return join(original_dir, resigned_name)
 
 
-def resign(ua, credential_dir, resigned_path):
-    """ Given a path to an uncompressed archive, credential directory, and desired
-        output path, resign accordingly """
+def resign(args):
+    """ Given a tuple consisting of a path to an uncompressed archive,
+        credential directory, and desired output path, resign accordingly """
+    ua, credential_dir, resigned_path = args
 
-    log.debug('resigning with %s %s -> %s', ua.path, credential_dir, resigned_path)
-    # get the credential files, create the 'signer'
-    credential_paths = isign.get_credential_paths(credential_dir)
-    signer = Signer(signer_cert_file=credential_paths['certificate'],
-                    signer_key_file=credential_paths['key'],
-                    apple_cert_file=isign.DEFAULT_APPLE_CERT_PATH)
+    try:
+        log.debug('resigning with %s %s -> %s', ua.path, credential_dir, resigned_path)
+        # get the credential files, create the 'signer'
+        credential_paths = isign.get_credential_paths(credential_dir)
+        signer = Signer(signer_cert_file=credential_paths['certificate'],
+                        signer_key_file=credential_paths['key'],
+                        apple_cert_file=isign.DEFAULT_APPLE_CERT_PATH)
 
-    # sign it (in place)
-    ua.bundle.resign(signer, credential_paths['provisioning_profile'])
+        # sign it (in place)
+        ua.bundle.resign(signer, credential_paths['provisioning_profile'])
 
-    log.debug("outputing %s", resigned_path)
-    # and archive it there
-    ua.archive(resigned_path)
+        log.debug("outputing %s", resigned_path)
+        # and archive it there
+        ua.archive(resigned_path)
+    finally:
+        ua.remove()
+
+
+def clone_ua(args):
+    original_ua, target_ua_path = args
+    log.debug('cloning %s to %s', original_ua.path, target_ua_path)
+    ua = original_ua.clone(target_ua_path)
+    log.debug('done cloning to %s', original_ua.path)
+    return ua
 
 
 def multisign(original_path, credential_dirs, info_props=None, prefix="_signed_"):
@@ -119,7 +132,7 @@ def multisign(original_path, credential_dirs, info_props=None, prefix="_signed_"
         If info_props are provided, it will overwrite those properties in
         the app's Info.plist.
     """
-    pass
+    p = Pool(MAX_PROCESSES)
 
     # ua is potentially an isign.archive.UncompressedArchive
     ua = None
@@ -132,24 +145,38 @@ def multisign(original_path, credential_dirs, info_props=None, prefix="_signed_"
     try:
         ua = archive.unarchive_to_temp()
         if info_props:
-            # Override info.plist props of the parent bundle
+            # Override info.plist props
             ua.bundle.update_info_props(info_props)
 
-        # create uncompressed archives for each credential to be signed
-        ua_credential_dir_pairs = [(ua, credential_dirs[0])]
-        for i in range(1, len(credential_dirs)):
-            cloned_ua = ua.clone(ua.path + '_' + str(i))
-            ua_credential_dir_pairs.append((cloned_ua, credential_dirs[i]))
+        # Since the signing process rewrites files, we must first create uncompressed archives
+        # for each credentials_directory.
+        # The first is simply the uncompressed archive we just made
+        uas = [ua]
 
-        # sign each uncompressed archive with credentials, and make archives
-        for pair in ua_credential_dir_pairs:
-            try:
-                (ua, credential_dir) = pair
-                log.debug("doing %s %s", ua.path, credential_dir)
-                resigned_path = get_resigned_path(original_path, credential_dir, prefix)
-                resign(ua, credential_dir, resigned_path)
-            finally:
-                ua.remove()
+        # But the rest need to be copied. This might take a while, so let's do it in parallel
+        # this will copy them to /path/to/uncompressedArchive_1, .._2, and so on
+        # and make UncompressedArchive objects that can be used for resigning
+        target_ua_paths = []
+        for i in range(1, len(credential_dirs)):
+            target_ua_paths.append((ua, ua.path + '_' + str(i)))
+        uas += p.map(clone_ua, target_ua_paths)
+
+        # now we should have one UncompressedArchive for every credential directory
+        assert len(uas) == len(credential_dirs)
+
+        # We will now construct arguments for all the resignings
+        resign_args = []
+        for i in range(0, len(credential_dirs)):
+            resign_args += [(
+                uas[i],
+                credential_dirs[i],
+                get_resigned_path(original_path, credential_dirs[i], prefix)
+            )]
+        log.debug('resign args: %s', resign_args)
+
+        # In parallel, resign each uncompressed archive with supplied credentials,
+        # and make archives in the desired paths.
+        p.map(resign, resign_args)
 
     except isign.NotSignable as e:
         msg = "Not signable: <{0}>: {1}\n".format(input_path, e)

--- a/bin/multisign
+++ b/bin/multisign
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+# From a single IPA, generate multiple re-signed IPAs simultaneously.
+# Why? Because you might want to distribute an app to a lot of organizations at once,
+# or perhaps you need to sign for an enterprise and a local debug deployment all at
+# the same time, and you want it to be fast.
+
+# Depends on the existence of external `zip` and `unzip` programs.
+
+import argparse
+from os.path import abspath, expanduser
+import logging
+
+FORMATTER = logging.Formatter('%(message)s')
+log = logging.getLogger(__name__)
+
+
+def log_to_stderr(level=logging.INFO):
+    root = logging.getLogger()
+    root.setLevel(level)
+    handler = logging.StreamHandler()
+    handler.setFormatter(FORMATTER)
+    root.addHandler(handler)
+
+
+def absolute_path_argument(path):
+    return abspath(expanduser(path))
+
+
+def parse_args():
+    # note that for arguments which eventually get fed into
+    # isign.resign, we deliberately don't set defaults. The kwarg
+    # defaults in isign.resign will be used
+    parser = argparse.ArgumentParser(
+        description='From a single IPA, generate multiple re-signed IPAs simultaneously')
+    parser.add_argument(
+        '-i', '--ipa',
+        dest='ipa',
+        required=True,
+        metavar='<file>',
+        type=absolute_path_argument,
+        help='Path to input IPA'
+    )
+    parser.add_argument(
+        'credential_paths',
+        nargs='+',
+        metavar='<directory>',
+        type=absolute_path_argument,
+        help='Paths to directories containing credentials with standardized names'
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        dest='verbose',
+        action='store_true',
+        default=False,
+        required=False,
+        help='Set logging level to debug.'
+    )
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    if args.verbose:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+    log_to_stderr(level)
+
+    log.debug('got credential paths: {}'.format(', '.join(args.credential_paths)))
+    log.debug('got incoming IPA: {}'.format(args.ipa))

--- a/bin/multisign
+++ b/bin/multisign
@@ -13,11 +13,12 @@ from isign import isign
 from isign.archive import archive_factory
 from isign.signer import Signer
 import logging
-from multiprocessing import Pool
+import multiprocessing
 
 FORMATTER = logging.Formatter('%(message)s')
-MAX_PROCESSES = 1
 log = logging.getLogger(__name__)
+
+MAX_PROCESSES = multiprocessing.cpu_count() - 1
 
 
 def log_to_stderr(level=logging.INFO):
@@ -132,7 +133,7 @@ def multisign(original_path, credential_dirs, info_props=None, prefix="_signed_"
         If info_props are provided, it will overwrite those properties in
         the app's Info.plist.
     """
-    p = Pool(MAX_PROCESSES)
+    p = multiprocessing.Pool(MAX_PROCESSES)
 
     # ua is potentially an isign.archive.UncompressedArchive
     ua = None

--- a/isign/archive.py
+++ b/isign/archive.py
@@ -242,10 +242,7 @@ class UncompressedArchive(object):
         a ContainingDir/Payload/something.app
 
         This class is also useful if you have an app that's already unzipped and
-        you want to sign it.
-
-        We also do some watchkit processing here, but only because it's a convenient
-        place to apply that hack """
+        you want to sign it. """
     def __init__(self, path, relative_bundle_dir, archive_class):
         """ Path is the "Containing dir", the dir at the root level of the unzipped archive
                 (or the dir itself, in the case of an AppArchive archive)

--- a/isign/archive.py
+++ b/isign/archive.py
@@ -299,7 +299,6 @@ def view(input_path):
         ua = archive.unarchive_to_temp()
         bundle_info = ua.bundle.info
     finally:
-        log.debug('finally....')
         if ua is not None:
             ua.remove()
     return bundle_info

--- a/isign/archive.py
+++ b/isign/archive.py
@@ -274,6 +274,7 @@ class UncompressedArchive(object):
         # the containing dir might be gone already b/c AppArchive simply moves
         # it to the desired target when done
         if exists(self.path) and isdir(self.path):
+            log.debug('removing ua: %s', self.path)
             shutil.rmtree(self.path)
 
 

--- a/isign/archive.py
+++ b/isign/archive.py
@@ -282,6 +282,8 @@ def view(input_path):
     bundle_info = None
     try:
         archive = archive_factory(input_path)
+        if archive is None:
+            raise NotMatched('No matching archive type found')
         ua = archive.unarchive_to_temp()
         bundle_info = ua.bundle.info
     finally:

--- a/isign/exceptions.py
+++ b/isign/exceptions.py
@@ -7,9 +7,14 @@ class NotSignable(Exception):
     pass
 
 
-class NotMatched(NotSignable):
+class NotMatched(Exception):
     """ thrown if we can't find any app class for
         this file path """
+    pass
+
+
+class MissingHelpers(NotSignable):
+    """ thrown if helper apps are missing """
     pass
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,6 @@
 import isign.archive
-from isign.archive import AppZip
-from isign.exceptions import NotSignable
+from isign.archive import AppZipArchive
+from isign.exceptions import MissingHelpers
 from isign_base_test import IsignBaseTest
 from distutils import spawn
 import logging
@@ -9,7 +9,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class MissingHelpersApp(AppZip):
+class MissingHelpersArchive(AppZipArchive):
     """ An App whose helpers are not present """
     helpers = ['a_file_that_should_never_be_present']
 
@@ -21,16 +21,16 @@ def dummy_find_executable(name):
 class TestHelpers(IsignBaseTest):
     def test_helpers_is_present(self):
         """ test that missing helpers raises exception """
-        with self.assertRaises(NotSignable):
-            MissingHelpersApp(self.TEST_APPZIP)
+        with self.assertRaises(MissingHelpers):
+            MissingHelpersArchive.precheck(self.TEST_APPZIP)
 
     def test_helpers_become_present(self):
         """ test that we can install helpers without restart """
-        with self.assertRaises(NotSignable):
-            MissingHelpersApp(self.TEST_APPZIP)
+        with self.assertRaises(MissingHelpers):
+            MissingHelpersArchive.precheck(self.TEST_APPZIP)
         spawn._original_find_executable = spawn.find_executable
         spawn.find_executable = dummy_find_executable
-        MissingHelpersApp(self.TEST_APPZIP)
+        MissingHelpersArchive.precheck(self.TEST_APPZIP)
         if hasattr(spawn, '_original_find_executable'):
             spawn.find_executable = spawn._original_find_executable
         isign.archive.helper_paths = {}

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -29,6 +29,9 @@ class TestPublicInterface(IsignBaseTest):
     def test_app_with_frameworks_ipa(self):
         self._test_signable(self.TEST_WITH_FRAMEWORKS_IPA, self.get_temp_file())
 
+    def test_appzip(self):
+        self._test_signable(self.TEST_APPZIP, self.get_temp_file())
+
     def test_non_app_txt(self):
         self._test_unsignable(self.TEST_NONAPP_TXT, self.get_temp_file())
 

--- a/version.sh
+++ b/version.sh
@@ -4,7 +4,7 @@
 # and also writes a `version.json` file into the package.
 
 set -e
-MAJMIN_VERSION="1.5"
+MAJMIN_VERSION="1.6"
 
 pushd $(dirname $0) >/dev/null
 working_dir=$PWD


### PR DESCRIPTION
Please review: @saucelabs/rdcdev 

The purpose here is to sign an app like an IPA with multiple credentials, simultaneously.

Changes made:
- Previously, one interacted with isign only by .resign(). If that worked, it worked. If it failed, it raised exceptions. Now, it's possible to "precheck" if an app is signable before resigning. 
   - We want to do all this pre-checking before an actual *Archive object is initialized. So some methods in the *Archive classes have been converted to class methods.

- The concept of "UncompressedArchive" was added to archive.py. We need to unzip files like an IPA before we can sign them. So now, one signs an UncompressedArchive, and then asks the UncompressedArchive to repackage itself back into whatever format it used to be. So think of it like this:
  - see what IpaArchive.precheck(some file) does 
  - if that works, then make an IpaArchive(some file)
  - uncompress it to UncompressedArchive(some temp directory)
  - resign the Bundle within
  - package up a new IpaArchive(target path)
  - delete the UncompressedArchive

- The multisign program uses all the above to uncompress one app archive, and then sign it with multiple credentials, and then zip them up to be similar to the original. If your machine has multiple processors, it will take advantage of that to speed things up.