### PR TITLE
Fix dirname command

### DIFF
--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -2,7 +2,7 @@
 set -e
 
 # determine local paths
-pushd $(dirname $0) >/dev/null
+pushd $(dirname "$0") >/dev/null
 DEV_DIR=$PWD
 cd ..
 SRC_DIR=$PWD


### PR DESCRIPTION
Fix `dirname` command return error because `pathname` has escape characters