### PR TITLE
Fix TypeError

### DIFF
--- a/isign/bundle.py
+++ b/isign/bundle.py
@@ -151,7 +151,7 @@ class Bundle(object):
                     continue
                 plist = biplist.readPlist(plist_path)
                 appex_exec_path = join(appex_path, plist['CFBundleExecutable'])
-                appex = signable.Appex(self, appex_exec_path)
+                appex = signable.Appex(self, appex_exec_path, signer)
                 appex.sign(self, signer)
 
         # then create the seal


### PR DESCRIPTION
The whole message was:
```
...
  File "/tmp/env/lib/site-packages/isign/bundle.py", line 159, in sign
TypeError: __init__() takes exactly 4 arguments (3 given)
```